### PR TITLE
Align inline icons and badge with text

### DIFF
--- a/content/build.html
+++ b/content/build.html
@@ -30,7 +30,7 @@ summary = "TODO"
       License text: <a href="{{< ref "/version/3/0/license.md" "html" >}}">HTML</a> <a href="{{< ref "/version/3/0/license.md" "markdown" >}}">Markdown</a>
     </li>
     <li>
-      License badge: <img src="https://img.shields.io/static/v1?label=Hippocratic%20License&message=HL3-ECO-LR&color=D44F2C">
+      License badge: <img class="badge-inline" src="https://img.shields.io/static/v1?label=Hippocratic%20License&message=HL3-ECO-LR&color=D44F2C">
     </li>
     <li>
       Badge markdown:

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -256,6 +256,10 @@ abbr {
 
 /* Named Classes */
 
+.badge-inline {
+  vertical-align: text-top;
+}
+
 .data-list {
   list-style: none;
   -moz-column-count: 1;
@@ -281,6 +285,7 @@ abbr {
   width: var(--font-size-regular);
   margin-right: .125rem;
   padding: .25rem .25rem .25rem .375rem;
+  vertical-align: text-top;
 }
 
 .icon a {


### PR DESCRIPTION
# Getting there

We were having some trouble getting inline icons and the GitHub badge aligned with the surrounding text, as shown:

# Interesting bits

* Adding `vertical-align: text-top;` to the icons and the badge fixed the appearance.

# Screenshots

## Before

<img width="524" alt="Screen Shot 2021-09-25 at 10 31 01 am" src="https://user-images.githubusercontent.com/5115928/134751774-2f104ce8-66ba-4da4-a360-cf30503eb705.png">

## After

<img width="521" alt="Screen Shot 2021-09-25 at 10 28 43 am" src="https://user-images.githubusercontent.com/5115928/134751797-80b823f6-81c0-4331-bfa5-60c3dec920a7.png">

