### PR TITLE
Make license-builder handle JS not being activated or custom elements not loaded

### DIFF
--- a/content/build.html
+++ b/content/build.html
@@ -8,48 +8,53 @@ summary = "Version 3.0 of the Hippocratic License, an Ethical Source license cre
 
 <h1>Build Your Hippocratic License</h1>
 
-<p>Instructions here. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nulla vitae elit libero, a pharetra augue. Curabitur blandit tempus porttitor. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
+<p>Instructions here.</p>
 
-<aside id="summary">
-  <h3>
-    {{< icon icon="clipboard-check" class="fill-black icon-large" >}}
-    Your license configuration
-  </h3>
+<verify-custom-elements>
+  <noscript><p>JavaScript needs to be enabled to use the license builder.</p></noscript>
+  <div style="display: none;">
+    <aside id="summary">
+      <h3>
+        {{< icon icon="clipboard-check" class="fill-black icon-large" >}}
+        Your license configuration
+      </h3>
 
-  <ol class="no-bullet">
-    <li><a href="#HL3">{{< icon icon="shield-check" class="fill=orange icon-normal" >}}Hippocratic License 3.0 (Core)</a></li>
-    <!-- <li><a href="#LABOR">{{< icon icon="shield-check" class="fill-orange icon-normal" >}}Labor Rights Module</a></li> -->
-  </ol>
+      <ol class="no-bullet">
+        <li><a href="#HL3">{{< icon icon="shield-check" class="fill=orange icon-normal" >}}Hippocratic License 3.0 (Core)</a></li>
+        <!-- <li><a href="#LABOR">{{< icon icon="shield-check" class="fill-orange icon-normal" >}}Labor Rights Module</a></li> -->
+      </ol>
 
-  <license-module-list type="active"></license-module-list>
+      <license-module-list type="active"></license-module-list>
 
-  <h3>
-    Start using your license
-  </h3>
+      <h3>
+        Start using your license
+      </h3>
 
-  <ul class="no-bullet">
-    <li>
-      License text: <a href="{{< ref "/version/3/0/full.html" "html" >}}">HTML</a> <a href="{{< ref "/version/3/0/full.html" "markdown" >}}">Markdown</a>
-    </li>
-    <li>
-      License badge: <img class="badge-inline" src="https://img.shields.io/static/v1?label=Hippocratic%20License&message=HL3-ECO-LR&color=D44F2C">
-    </li>
-    <li>
-      Badge markdown:
-      <code>
-        ![https://img.shields.io/static/v1?label=Hippocratic%20License&message=HL3-ECO-LR&color=D44F2C](https://img.shields.io/static/v1?label=Hippocratic%20License&message=HL3-ECO-LR&color=D44F2C)
-      </code>
-    </li>
-  </ul>
+      <ul class="no-bullet">
+        <li>
+          License text: <a href="{{< ref "/version/3/0/full.html" "html" >}}">HTML</a> <a href="{{< ref "/version/3/0/full.html" "markdown" >}}">Markdown</a>
+        </li>
+        <li>
+          License badge: <img class="badge-inline" src="https://img.shields.io/static/v1?label=Hippocratic%20License&message=HL3-ECO-LR&color=D44F2C">
+        </li>
+        <li>
+          Badge markdown:
+          <code>
+            ![https://img.shields.io/static/v1?label=Hippocratic%20License&message=HL3-ECO-LR&color=D44F2C](https://img.shields.io/static/v1?label=Hippocratic%20License&message=HL3-ECO-LR&color=D44F2C)
+          </code>
+        </li>
+      </ul>
 
-  <h3>
-    Available modules
-  </h3>
+      <h3>
+        Available modules
+      </h3>
 
-  <license-module-list type="inactive"></license-module-list>
+      <license-module-list type="inactive"></license-module-list>
 
-</aside>
+    </aside>
 
-<div class="no-bullet-wrapper">
-{{< hl3-full-license >}}
-</div>
+    <div class="no-bullet-wrapper">
+    {{< hl3-full-license >}}
+    </div>
+  </div>
+</verify-custom-elements>

--- a/static/scripts/VerifyCustomElements.js
+++ b/static/scripts/VerifyCustomElements.js
@@ -1,0 +1,46 @@
+import { cr } from './licenseBuilder.helpers.js'
+import { webComponents } from './licenseBuilder.js'
+
+/**
+ * Purpose: Avoid showing content unless specified custom elements
+ * have loaded. This is to avoid showing a configured license with
+ * the wrong modules showing because the user does not have JavaScript
+ * activated.
+ *
+ * Usage example:
+ *
+ * <verify-custom-elements>
+ *  <noscript>JavaScript needs to be enabled to view the configured license.</noscript>
+ *  <div style="display:none;">
+ *    <!-- content -->
+ *  </div>
+ * </verify-custom-elements>
+ */
+export class VerifyCustomElements extends HTMLElement {
+  constructor() {
+    super()
+    this.checkIfModulesLoaded = this.checkIfModulesLoaded.bind(this)
+  }
+
+  checkIfModulesLoaded() {
+    const isAllModulesLoaded = Object.keys(webComponents).every((tagName) =>
+      customElements.get(tagName)
+    )
+    if (!isAllModulesLoaded) {
+      return // do nothing
+    }
+    const firstDiv = this.querySelector('div')
+    firstDiv.style = ''
+    clearInterval(this.intervalID)
+    this.intervalID = undefined
+  }
+
+  connectedCallback() {
+    this.intervalID = setInterval(this.checkIfModulesLoaded, 1000)
+    this.checkIfModulesLoaded()
+  }
+
+  disconnectedCallback() {
+    clearInterval(this.intervalID)
+  }
+}

--- a/static/scripts/licenseBuilder.js
+++ b/static/scripts/licenseBuilder.js
@@ -1,10 +1,12 @@
 import { LicenseModule } from './LicenseModule.js'
 import { LicenseModuleList } from './LicenseModuleList.js'
+import { VerifyCustomElements } from './VerifyCustomElements.js'
 import { enableLocationChangeEvent } from './locationchangePolyfill.js'
 
-const webComponents = {
+export const webComponents = {
   'license-module-list': LicenseModuleList,
   'license-module': LicenseModule,
+  'verify-custom-elements': VerifyCustomElements,
 }
 
 function loadWebComponents() {


### PR DESCRIPTION
# Milestone
License builder now checks if required custom elements have been loaded. This avoids issues where users would see a misconfigured license due to JS not being properly loaded.

Resolves #22.

# Getting there
* I built a custom component `<verify-custom-elements />` that verifies that all the modules defined in `licenseBuilder.js` have loaded properly and only then show the license builder.

# Interesting bits
* I included the use of a `<noscript></noscript>` to be able to display a message to users with JS fully deactivated.

# What I need help with
* Not so much on this PR I think. Though, if there is an edge-case I haven't thought about be sure to let me know.

# What's next
After merging, this PR should allow us to:

* Tackle the other issues. 🙂 
