### PR TITLE
:bug: Fix license link to be 'full' when all modules are active.

### DIFF
--- a/layouts/partials/web-components/configured-license-link.html
+++ b/layouts/partials/web-components/configured-license-link.html
@@ -1,8 +1,11 @@
 <script type="module">
   import {
     getActiveModules,
+    getAllModules,
     cr,
   } from '/scripts/license-builder/license-builder.helpers.mjs'
+
+  const allModules = getAllModules()
 
   /**
    * Purpose: Dynamically create a link to the configured
@@ -33,6 +36,8 @@
       // Assume it's core license
       if (modules.length === 0) {
         this.link.href = `/version/3/0/core${fileEnding}`
+      } else if (modules.length === allModules.length) {
+        this.link.href = `/version/3/0/full${fileEnding}`
       } else {
         this.link.href = `/version/3/0/${modules
           .join('-')


### PR DESCRIPTION
Fixes #40

# Milestone
Shortens license link to "full" when all modules are active. This was worked before until I managed to introduce a bug.

Examples of links we have after merging this will be
- https://hl3.netlify.app/version/3/0/full.txt
- https://hl3.netlify.app/version/3/0/core.md
- https://hl3.netlify.app/version/3/0/bds-tal.html

# Getting there
* Discovered and fixed a bug in `configured-license-link.html` so that links are now properly shortened when all modules are active.

# What's next

* We can discuss better formats for the license links. Though, that might require non-trivial amount of coding to change. 😅  
