### PR TITLE
:UP: upgrade to latest Node LTS

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,8 +10,8 @@
 
 [functions]
   node_bundler = "esbuild"
-  # Prevent error thrown by JSDOM.
-  external_node_modules = ["canvas"]
+  # Fix esbuild warnings thrown by JSDOM.
+  external_node_modules = ["canvas", "./xhr-sync-worker.js"]
 
 # Enable SPA functionality for License builder page
 # Urls like "/build/hl-bsd-eco", should always

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,11 +8,6 @@
   HUGO_VERSION = "0.88.1"
   NODE_VERSION = "lts/*"
 
-[functions]
-  node_bundler = "esbuild"
-  # Prevent error thrown by JSDOM.
-  external_node_modules = ["canvas"]
-
 # Enable SPA functionality for License builder page
 # Urls like "/build/hl-bsd-eco", should always
 # hit the javascript code which will select proper

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,8 +10,8 @@
 
 [functions]
   node_bundler = "esbuild"
-  # Fix esbuild warnings thrown by JSDOM.
-  external_node_modules = ["canvas", "./xhr-sync-worker.js"]
+  # Prevent error thrown by JSDOM.
+  external_node_modules = ["canvas"]
 
 # Enable SPA functionality for License builder page
 # Urls like "/build/hl-bsd-eco", should always

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,10 +6,7 @@
 
 [build.environment]
   HUGO_VERSION = "0.88.1"
-  NODE_VERSION = "14.18.0"
-  NPM_VERSION = "8.x"
-  # Netlify functions runtime version
-  AWS_LAMBDA_JS_RUNTIME = "nodejs14.x"
+  NODE_VERSION = "lts/*"
 
 [functions]
   node_bundler = "esbuild"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,8 @@
 
 [functions]
   node_bundler = "esbuild"
+  # Prevent error thrown by JSDOM.
+  external_node_modules = ["canvas"]
 
 # Enable SPA functionality for License builder page
 # Urls like "/build/hl-bsd-eco", should always

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "prettier-plugin-go-template": "0.0.11"
       },
       "engines": {
-        "node": ">=14.x",
+        "node": ">=16.x",
         "npm": ">=8.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "engines": {
-    "node": ">=14.x",
+    "node": ">=16.x",
     "npm": ">=8.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #55 . 

# Milestone

Stop being locked to Node v14, and just start tracking the latest Node LTS release. 

# Getting there

1. Use NVM configuration syntax to select latest Node LTS release. 
1. Removing NPM config so that it will track the LTS Node version. 
1. Removing Netlify function version specification so that it will just use latest LTS release.
1. Also, I saw some warnings in the Netlify build log related to esbuild for function bundling which is beta functionality. I tried to fix it but eventually gave up and removed it from the build step. Esbuild didn't really provide us with any needed functionality there. See: https://github.com/EthicalSource/hippocratic-license-3/pull/57/commits/31cb93cafe1c291ad0f08c9e7084105f0927fb43

# Interesting bits
- Moving forward we should just have the latest LTS release for this code. So we shouldn't have to keep coming back to update this.
- Worth noting that all NPM dependencies are pinned to specific version numbers, and we have been quite conservative about how many dependencies we have included. 
- Node only runs in the build step and in the Netlify lambda functions. 

# What I need help with
* Just another pair of eyes to check that overall functionality hasn't broken. 

# What's next
After merging, this PR should allow us to:

* Do less security maintenance work. 
