### PR TITLE
Licence builder: a few minor design improvements

### DIFF
--- a/assets/sass/button.component.scss
+++ b/assets/sass/button.component.scss
@@ -5,6 +5,7 @@
   font-weight: 700;
   color: var(--color-orange);
   border-radius: 10px;
+  transition: var(--hover-transition);
   &:hover {
     background-color: var(--color-orange);
     color: var(--color-white);

--- a/assets/sass/license-badge.component.scss
+++ b/assets/sass/license-badge.component.scss
@@ -13,7 +13,7 @@
     right: 0;
     z-index: 1;
     cursor: pointer;
-    transition: all 0.1s ease-in-out;
+    transition: var(--hover-transition);
     border: 1px solid var(--color-orange-darker);
     border-radius: 0.25rem;
     background: var(--color-white);
@@ -52,5 +52,6 @@
     border-radius: 0.25rem;
     padding: 1rem;
     margin: 0;
+    font-size: 0.7em;
   }
 }

--- a/assets/sass/license-builder.component.scss
+++ b/assets/sass/license-builder.component.scss
@@ -12,6 +12,9 @@ handled by the .license-page component.
   h3 {
     margin: 2rem 0;
   }
+  .h3-light {
+    font-weight: normal;
+  }
   &__module-buttons {
     display: flex;
     justify-content: flex-end;

--- a/assets/sass/license-page.component.scss
+++ b/assets/sass/license-page.component.scss
@@ -51,10 +51,11 @@
   .license-builder__modules {
     overflow-y: scroll;
     max-height: 48vh;
-  }
-  .license-builder__modules:after {
-    content: '_';
-    visibility: hidden;
-    min-width: 0.1px;
+    position: relative;
+    width: calc(100% + 2rem); /* parent's padding-block = 1px */
+    left: -1rem;
+    padding-block: 1rem;
+    padding-inline: 1rem;
+    background-color: var(--color-white-darker);
   }
 }

--- a/assets/sass/variables.scss
+++ b/assets/sass/variables.scss
@@ -3,6 +3,7 @@
 :root {
   --color-primary: #462921; /* "ground" */
   --color-white: #fdf6ec; /* "soft white" */
+  --color-white-darker: #f4ecdf; /* "slightly darker white" */
   --color-grey: #eee; /* "light grey" */
   --color-black: #1a1a1a; /* "off black" */
   --color-orange: #d44f2c; /* "terracotta" */
@@ -23,4 +24,6 @@
 
   --font-weight-regular: 400;
   --font-weight-heavy: 700;
+
+  --hover-transition: all 0.1s ease-in-out;
 }

--- a/layouts/shortcodes/license-builder.html
+++ b/layouts/shortcodes/license-builder.html
@@ -1,6 +1,6 @@
 <section class="license-builder">
   <h2 class="license-builder__title">License builder</h2>
-  <h3>Available modules (scrollable list)</h3>
+  <h3>Available modules <span class="h3-light">(scrollable list)</span></h3>
   <div class="license-builder__modules">
     <module-list></module-list>
   </div>


### PR DESCRIPTION
A few minor design improvements for the licence builder:

- `(scrollable list)` after `Available modules` not bold anymore for visual hierarchie
- the modules list now got a slightly darker BG for visual hierarchie
- enabled the 0.1s hover transition for all buttons
- the badge markdown code is a bit smaller now