### PR TITLE
docs: update links (#63)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 ## Getting started
-Please check the [issues](https://github.com/EthicalSource/hippocratic-license/issues)
+Please check the [issues](https://github.com/EthicalSource/hippocratic-license-3/issues)
 for the latest discussions, questions, and ideas for the Hippocratic License and this site.
 
 ## What you need to know

--- a/content/adopters.md
+++ b/content/adopters.md
@@ -11,4 +11,4 @@ The Hippocratic License has been adopted by [hundreds of projects](https://githu
 {{< data-list "static/adopters.csv" >}}
 
 To add your project to this list, please [submit a pull
-request](https://github.com/EthicalSource/hippocratic-license/blob/release/CONTRIBUTING.md#adding-a-project-to-the-list-of-adopters "Hippocratic License source code").
+request](https://github.com/EthicalSource/hippocratic-license-3/blob/release/CONTRIBUTING.md#adding-a-project-to-the-list-of-adopters "Hippocratic License source code").

--- a/content/adopters.md
+++ b/content/adopters.md
@@ -11,4 +11,4 @@ The Hippocratic License has been adopted by [hundreds of projects](https://githu
 {{< data-list "static/adopters.csv" >}}
 
 To add your project to this list, please [submit a pull
-request](https://github.com/EthicalSource/hippocratic-license-3/blob/release/CONTRIBUTING.md#adding-a-project-to-the-list-of-adopters "Hippocratic License source code").
+request](https://github.com/EthicalSource/hippocratic-license-3/blob/release/CONTRIBUTING.md#adding-your-project-to-the-list-of-adopters "Hippocratic License source code").

--- a/content/contribute.md
+++ b/content/contribute.md
@@ -14,7 +14,7 @@ If you'd like to participate in this program, sign up for membership in the OES 
 You can support our work with a one-time or recurring donation through [Open Collective](https://opencollective.com/ethical-source).
 
 ### Other Ways of Contributing
-Contributions in the form of [issues and pull requests](https://github.com/EthicalSource/hippocratic-license "Hippocratic License source code") in our source repository are also welcomed and encouraged.
+Contributions in the form of [issues and pull requests](https://github.com/EthicalSource/hippocratic-license-3 "Hippocratic License source code") in our source repository are also welcomed and encouraged.
 
 ### Special Thanks
-We are grateful for the contributions of [Sameeul Haque](https://www.linkedin.com/in/sameeul-haque/), [Matt Boehm](https://twitter.com/bigolewannabe), Greg McMullen, [Brad Simon](https://bradsimonlaw.com), [Luis Villa](https://twitter.com/luis_in_brief), the members of the [Ethical Source Licensure Working Group](https://ethicalsource.dev), and our contributors on [GitHub](https://github.com/EthicalSource/hippocratic-license).
+We are grateful for the contributions of [Sameeul Haque](https://www.linkedin.com/in/sameeul-haque/), [Matt Boehm](https://twitter.com/bigolewannabe), Greg McMullen, [Brad Simon](https://bradsimonlaw.com), [Luis Villa](https://twitter.com/luis_in_brief), the members of the [Ethical Source Licensure Working Group](https://ethicalsource.dev), and our contributors on [GitHub](https://github.com/EthicalSource/hippocratic-license-3).


### PR DESCRIPTION
# Milestone

Keeps repo links up to date.

# Getting there

- For #63 Changes links that point to the archived repo https://github.com/EthicalSource/hippocratic-license to point to this one.
- Fixes the link to a markdown section the heading of which has changed.

# Interesting bits

x

# What I need help with

x

# What's next

x