### PR TITLE
Remove python-install

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -18,7 +18,6 @@ leisure, https://leisure.tdreyno.com
 libhoney-kotlin,https://github.com/imavroukakis/libhoney-kotlin
 NLPIA-bot Chatbot, https://github.com/nlpia/nlpia-bot
 Pangolin, https://pangolinjs.org
-python-install, https://github.com/FFY00/python-install
 postgres-mitm, https://github.com/thusoy/postgres-mitm
 rack-read_only, https://rubygems.org/gems/rack-read_only
 react-leaflet, https://github.com/PaulLeCam/react-leaflet


### PR DESCRIPTION
I checked this morning and `python-install` (at https://github.com/FFY00/python-install ) uses the MIT license and there has been no change to its LICENSE files for 3 years.