### PR TITLE
Remove unreliable github search link

### DIFF
--- a/content/adopters.md
+++ b/content/adopters.md
@@ -6,7 +6,7 @@ summary = "The Hippocratic License has been adopted by over 300 open source proj
 
 ## Hippocratic License Adopters
 
-The Hippocratic License has been adopted by [hundreds of projects](https://github.com/search?q=%22Hippocratic+License%22+filename%3ALICENSE*&type=commits) including:
+The Hippocratic License has been adopted by hundreds of projects, including:
 
 {{< data-list "static/adopters.csv" >}}
 


### PR DESCRIPTION
Removed the link to the Github search query for adoptions, as the signal-to-noise in those search results made discovery difficult.
