### PR TITLE
Add pearlOS to list of adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -18,6 +18,7 @@ leisure, https://leisure.tdreyno.com
 libhoney-kotlin,https://github.com/imavroukakis/libhoney-kotlin
 NLPIA-bot Chatbot, https://github.com/nlpia/nlpia-bot
 Pangolin, https://pangolinjs.org
+pearlOS, https://github.com/callmesalmon/pearlOS
 postgres-mitm, https://github.com/thusoy/postgres-mitm
 rack-read_only, https://rubygems.org/gems/rack-read_only
 react-leaflet, https://github.com/PaulLeCam/react-leaflet


### PR DESCRIPTION
The title makes this PR self explanatory, [pearlOS](https://github.com/callmesalmon/pearlOS) has
switched to the hippocratic-3 license (core) and I thought that I might as well add it to the list of adopters.
