### PR TITLE
Remove the netlify builder

### DIFF
--- a/netlify/functions/debug.js.deactivated
+++ b/netlify/functions/debug.js.deactivated
@@ -1,5 +1,3 @@
-import { builder } from '@netlify/functions'
-
 /**
  * Rename this file to '.js' to use this as a useful helper
  * when working with Netlify functions.
@@ -38,4 +36,4 @@ async function debugHandler(event, context) {
   }
 }
 
-export const handler = builder(debugHandler)
+export const handler = debugHandler

--- a/netlify/functions/download-license.js
+++ b/netlify/functions/download-license.js
@@ -1,5 +1,4 @@
 import { JSDOM } from 'jsdom'
-import { builder } from '@netlify/functions'
 import { licenseHTML } from '../hl-full.js'
 import { convert } from 'html-to-text'
 import { NodeHtmlMarkdown } from 'node-html-markdown'
@@ -164,4 +163,4 @@ export function parseActiveModules(urlPath) {
 }
 
 // Handler property is used by Netlify
-export const handler = builder(downloadLicenseHandler)
+export const handler = downloadLicenseHandler

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "@netlify/functions": "0.10.0",
         "html-to-text": "8.1.0",
         "husky": "8.0.1",
         "jsdom": "19.0.0",
@@ -17,19 +16,8 @@
         "prettier-plugin-go-template": "0.0.11"
       },
       "engines": {
-        "node": ">=22.x",
-        "npm": ">=10.x"
-      }
-    },
-    "node_modules/@netlify/functions": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-0.10.0.tgz",
-      "integrity": "sha512-NNFADTPnokuoMY1OUhaXlE/Jrzk5lHOl1uB4L/8pw1UJ/CaectZJACMExijbJnqaKIhOQG0WmbBQUh1lgnK/Qg==",
-      "dependencies": {
-        "is-promise": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.3.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@selderee/plugin-htmlparser2": {
@@ -926,11 +914,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
-    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -1502,6 +1485,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -1992,14 +1976,6 @@
     }
   },
   "dependencies": {
-    "@netlify/functions": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-0.10.0.tgz",
-      "integrity": "sha512-NNFADTPnokuoMY1OUhaXlE/Jrzk5lHOl1uB4L/8pw1UJ/CaectZJACMExijbJnqaKIhOQG0WmbBQUh1lgnK/Qg==",
-      "requires": {
-        "is-promise": "^4.0.0"
-      }
-    },
     "@selderee/plugin-htmlparser2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
@@ -2618,11 +2594,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
-    "is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
-    },
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3018,7 +2989,8 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "prettier-plugin-go-template": {
       "version": "0.0.11",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "prettier-plugin-go-template": "0.0.11"
   },
   "dependencies": {
-    "@netlify/functions": "0.10.0",
     "html-to-text": "8.1.0",
     "husky": "8.0.1",
     "jsdom": "19.0.0",


### PR DESCRIPTION
Closes #94 

# Milestone
Using the license builder produces the error:

>  Runtime.CallbackHandlerDeprecated - ERROR: AWS Lambda has removed support for callback-based function handlers starting with Node.js 24. You need to modify this function to use a supported handler signature to use Node.js 24 or later. For more information see https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html. 

It looks like the underlying AWS environment changed at some point. Looks like we can export the handlers directly without needing the builder in `@netlify/functions`.

# Interesting bits
* Care should be taken to make sure we didn't lose anything or cause regressions

# What I need help with
* Making sure the netlify deploy preview looks right

# What's next
After merging, this PR should allow us to :
* Have a working site!

I'll follow up with node dependency updates after this is merged. 